### PR TITLE
fix: UnboundLocalError when path is empty list or all paths are invalid

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "ymodem"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "ordered-set" },

--- a/ymodem/Socket.py
+++ b/ymodem/Socket.py
@@ -125,6 +125,10 @@ class ModemSocket(Channel):
                 if os.path.isfile(path):
                     tasks.append(_TransmissionTask(path))
 
+            if len(tasks) == 0:
+                self.logger.warning("[Sender]: No valid files found in paths. Cancelling transfer.")
+                return False
+
             for task_index, task in enumerate(tasks):
 
                 try:


### PR DESCRIPTION
```sh
❯ uv run ymodem send /path/to/invalid_path -p COM6 -b 115200
Port COM6 opened
Waiting for command from Receiver...
cannot access local variable 'crc' where it is not associated with a value
...
UnboundLocalError: cannot access local variable 'crc' where it is not associated with a value
```

Cancel transfer when all paths are invalid to avoid UnboundLocalError 

```sh
❯ uv run ymodem send /path/to/invalid_path -p COM6 -b 115200
Port COM6 opened
Waiting for command from Receiver...
[Sender]: No valid files found in paths. Cancelling transfer.

Port COM6 closed
```